### PR TITLE
Using '$0' instead of 'code here' comment

### DIFF
--- a/cpp.json
+++ b/cpp.json
@@ -32,7 +32,7 @@
 			"int T;",
 			"cin >> T;",
 			"while(T--) { ",
-			"\tcode here",
+			"\t$0",
 			"}"
 		],
 		"description": "make test case templete"
@@ -42,7 +42,7 @@
 		"prefix": ["rep1"],
 		"body": [
 			"for(int i=0; i<N; i++) {",
-			"\tcode here",
+			"\t$0",
 			"}"
 		],
 		"description": "make repeat-1 templete"
@@ -53,7 +53,7 @@
 		"body": [
 			"for(int i=0; i<N; i++) {",
 			"\tfor(int j=0; j<N; j++) {",
-			"\t\tcode here",
+			"\t\t$0",
 			"\t}",
 			"}"
 		],


### PR DESCRIPTION
$0를 하면 바로 그 위치에 커서가 가는 VSCode에 기능이 있습니다.
이 기능을 적용시켜, code here 대신 사용자가 더 편하게 이용할 수 있도록 하였습니다!